### PR TITLE
Update plugin_utils.py

### DIFF
--- a/plugin_utils.py
+++ b/plugin_utils.py
@@ -267,6 +267,7 @@ class PluginApplication(QtWidgets.QApplication):
         text_color = QtGui.QColor(sigil_colors("Text"))
         p.setColor(QtGui.QPalette.Window, dark_color)
         p.setColor(QtGui.QPalette.WindowText, text_color)
+        p.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.WindowText, disabled_color)
         p.setColor(QtGui.QPalette.Base, QtGui.QColor(sigil_colors("Base")))
         p.setColor(QtGui.QPalette.AlternateBase, dark_color)
         p.setColor(QtGui.QPalette.ToolTipBase, dark_color)


### PR DESCRIPTION
Missing disabled for WindowText.

This is important, among other things, for the disabled QLabel:
![plugin_utils_image](https://github.com/user-attachments/assets/d2d7a7c8-ee43-4b2b-8c76-5fffa2b3c1df)
